### PR TITLE
Update MQTT client ID logic

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -74,6 +74,15 @@ func main() {
 
 	// Load configuration from environment variables
 	cfg := config.Load()
+	// Try to use the node long name as MQTT client ID when available
+	if info, err := mqttpkg.GetLocalNodeInfoCached(cfg.SerialPort, "nodes.json"); err == nil {
+		if ln := strings.TrimSpace(info.LongName); ln != "" {
+			cfg.ClientID = ln
+		}
+	} else {
+		log.Printf("⚠️  impossibile ottenere long name nodo: %v", err)
+	}
+
 	nodes := nodemap.New()
 	mgmt := mgmtapi.New(cfg.MgmtURL)
 


### PR DESCRIPTION
## Summary
- read node info at startup and, if available, use the node long name as the MQTT client ID

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e75edc7108323bd767b849db57c15