### PR TITLE
Update client API for new server endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ The server exposes the following JSON endpoints, mirrored from the
 * `POST /nodes` – register a node and receive `201 Created` or `202 Accepted`
 * `POST /nodes/reset` – remove all nodes while keeping pending requests
 
+### Client endpoints
+
+Endpoints for local clients physically connected via USB:
+
+* `GET /clients` – list connected clients
+* `POST /clients` – register a new client using the same payload as `POST /nodes` with `"client": true`
+* `POST /clients/reset` – remove all stored clients
+
 ### Node management
 
 * `GET /nodes/{id}/backups` – list stored configuration backups


### PR DESCRIPTION
## Summary
- handle `/clients` endpoints in mgmt client
- include new NodePayload struct with `client` flag
- add tests for client endpoints
- document client REST APIs in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6876d9af27f08323a53470fc0a44d82e