### PR TITLE
Add logging for HTTP request failures

### DIFF
--- a/mgmtapi/client.go
+++ b/mgmtapi/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -93,11 +94,14 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		c.connected = false
+		log.Printf("request to %s failed: %v", req.URL, err)
 		return nil, err
 	}
 	if resp.StatusCode >= 300 {
 		c.connected = false
-		return resp, fmt.Errorf("server returned %s", resp.Status)
+		err = fmt.Errorf("server returned %s", resp.Status)
+		log.Printf("request to %s failed: %v", req.URL, err)
+		return resp, err
 	}
 	c.connected = true
 	return resp, nil


### PR DESCRIPTION
## Summary
- log the request URL whenever an HTTP request fails or returns an error status

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876eb279b008323bcb0e59e4cdbc329